### PR TITLE
Scala-Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+notifications:
+  email:
+  - hartmut_juergens@yahoo.de

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# taglist-maven-plugin
+Taglist Maven Plugin
+
+Supports also tags in Scala source files.

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-changes-plugin</artifactId>
-        <version>2.1</version>
+        <version>2.11</version>
         <configuration>
           <columnNames>Key,Summary,Status,Resolution,Assignee,Type,Version,Fix Version</columnNames>
           <sortColumnNames>Fix Version</sortColumnNames>

--- a/src/main/java/org/codehaus/mojo/taglist/FileAnalyser.java
+++ b/src/main/java/org/codehaus/mojo/taglist/FileAnalyser.java
@@ -109,6 +109,11 @@ public class FileAnalyser
     private ArrayList tagClasses = new ArrayList();
 
     /**
+     * String used to configure the file filter.
+     */
+    private final String fileSuffix;
+
+    /**
      * Constructor.
      * 
      * @param report the MOJO that is using this analyzer.
@@ -122,7 +127,8 @@ public class FileAnalyser
         sourceDirs = report.constructSourceDirs();
         encoding = report.getEncoding();
         locale = report.getLocale();
-        noCommentString = report.getBundle().getString( "report.taglist.nocomment" );      
+        noCommentString = report.getBundle().getString( "report.taglist.nocomment" );
+        fileSuffix = report.getFileSuffix();
         this.tagClasses = tagClasses;
     }
 
@@ -166,12 +172,18 @@ public class FileAnalyser
     private List findFilesToScan()
         throws MavenReportException
     {
+        String pattern = "";
+        for ( String suffix : StringUtils.split( fileSuffix, "," ) )
+        {
+            pattern += "**/*." + StringUtils.removeStart( suffix, "." );
+        }
+
         List filesList = new ArrayList();
         try
         {
             for ( Iterator iter = sourceDirs.iterator(); iter.hasNext(); )
             {
-                filesList.addAll( FileUtils.getFiles( new File( (String) iter.next() ), "**/*.java", null ) );
+                filesList.addAll( FileUtils.getFiles( new File( (String) iter.next() ), pattern, null ) );
             }
         }
         catch ( IOException e )

--- a/src/main/java/org/codehaus/mojo/taglist/TagListReport.java
+++ b/src/main/java/org/codehaus/mojo/taglist/TagListReport.java
@@ -190,6 +190,14 @@ public class TagListReport
     private boolean showEmptyDetails;
 
     /**
+     * Specifies the suffix of the files for which a report will be generated.
+     *
+     * @parameter default-value="java"
+     * @since 2.5
+     */
+    private String  fileSuffix;
+
+    /**
      * Skips reporting of test sources.
      * 
      * @parameter default-value="false"
@@ -229,7 +237,7 @@ public class TagListReport
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.apache.maven.reporting.AbstractMavenReport#executeReport(java.util.Locale)
      */
     protected void executeReport( Locale locale )
@@ -319,6 +327,12 @@ public class TagListReport
                 // Add this new tag class to the container.
                 tagClasses.add( tc );
             }
+        }
+
+        // User entered no or empty file suffix, then default to "java"
+        if ( StringUtils.isEmpty(fileSuffix) )
+        {
+            fileSuffix = "java";
         }
 
         // let's proceed to the analysis
@@ -496,6 +510,7 @@ public class TagListReport
      */
     private boolean hasSources( File dir )
     {
+
         boolean found = false;
         if ( dir.exists() && dir.isDirectory() )
         {
@@ -503,9 +518,20 @@ public class TagListReport
             for ( int i = 0; i < files.length && !found; i++ )
             {
                 File currentFile = files[i];
-                if ( currentFile.isFile() && currentFile.getName().endsWith( ".java" ) )
+                if ( currentFile.isFile()   )
                 {
-                    found = true;
+                    if ( StringUtils.isEmpty( fileSuffix ) && currentFile.getName().endsWith( ".java" ) )
+                    {
+                        found = true;
+                    }
+                    else
+                    {
+                        for ( String suffix : StringUtils.split( fileSuffix, "," ) )
+                        {
+                            String pointSuffix = "." + StringUtils.stripStart( suffix, "." );
+                            found |= currentFile.getName().endsWith( pointSuffix );
+                        }
+                    }
                 }
                 else if ( currentFile.isDirectory() )
                 {
@@ -601,12 +627,22 @@ public class TagListReport
 
     /**
      * Tells whether to generate details for tags with zero occurrences.
-     * 
+     *
      * @return the showEmptyTags.
      */
     public boolean isShowEmptyDetails()
     {
         return showEmptyDetails;
+    }
+
+    /**
+     * Returns the suffix considered in file filtering.
+     *
+     * @return the fileSuffix.
+     */
+    public String getFileSuffix()
+    {
+        return fileSuffix;
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/taglist/beans/FileReport.java
+++ b/src/main/java/org/codehaus/mojo/taglist/beans/FileReport.java
@@ -20,6 +20,8 @@ package org.codehaus.mojo.taglist.beans;
  */
 
 import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.StringUtils;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -164,7 +166,16 @@ public class FileReport
             IOUtil.close( reader );
         }
 
-        className = packageName + "." + file.getName().replaceAll( "\\.java$", "" );
+        String packagelessClassName = file.getName();
+        for ( String suffix : new String[]{ ".java", ".scala" } )
+        {
+            final int index = packagelessClassName.lastIndexOf( suffix );
+            if ( index > -1 )
+            {
+                packagelessClassName = packagelessClassName.substring( 0, index );
+            }
+        }
+        className = packageName + "." + packagelessClassName;
 
         return className;
     }

--- a/src/test/java/org/codehaus/mojo/taglist/beans/FileReportTestCase.java
+++ b/src/test/java/org/codehaus/mojo/taglist/beans/FileReportTestCase.java
@@ -29,8 +29,13 @@ import org.codehaus.plexus.PlexusTestCase;
  */
 public class FileReportTestCase extends PlexusTestCase
 {
-  public void testGetClassName() {
-    File file = new File(getBasedir() + "/src/test/resources/org/codehaus/mojo/taglist/beans/XYjavatest.java");
+  public void testGetClassNameJava() {
+    File file = getTestFile( "/src/test/resources/org/codehaus/mojo/taglist/beans/XYjavatest.java" );
+    FileReport fileReport = new FileReport(file, "UTF-8");
+    assertEquals("org.codehaus.mojo.taglist.beans.XYjavatest", fileReport.getClassName());
+  }
+  public void testGetClassNameScala() {
+    File file = getTestFile( "/src/test/resources/org/codehaus/mojo/taglist/beans/XYjavatest.scala" );
     FileReport fileReport = new FileReport(file, "UTF-8");
     assertEquals("org.codehaus.mojo.taglist.beans.XYjavatest", fileReport.getClassName());
   }

--- a/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoBasicConfigTest.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoBasicConfigTest.java
@@ -1,0 +1,306 @@
+package org.codehaus.mojo.taglist.scala;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.codehaus.mojo.taglist.AbstractTaglistMojoTestCase;
+import org.codehaus.mojo.taglist.TagListReport;
+import org.codehaus.plexus.util.FileUtils;
+
+/**
+ * Test the Taglist mojo basic configurations.
+ *
+ * @version $Id$
+ */
+public class TaglistMojoBasicConfigTest
+    extends AbstractTaglistMojoTestCase
+{
+
+    /** {@inheritDoc} */
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+    }
+
+    /** {@inheritDoc} */
+    protected void tearDown()
+        throws Exception
+    {
+        super.tearDown();
+    }
+
+    /**
+     * Test that all of the default settings are correct.
+     *
+     * @throws Exception
+     */
+    public void testCreateTagListOutput()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/create-output-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see is the com.Basic file was processed.
+        String expected = "<tr class=\"a\"><th>com.BasicConfig</th>";
+        assertTrue("Missing tag result.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test support of multiple line comments enabled.
+     *
+     * @throws Exception
+     */
+    public void testMultipleLineCommentsEnabled()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/multiple-line-comments-enabled-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see that all three lines of the comment are captured.
+        String expected = "<td>This is line one, this is line two, and this is line three.</td>";
+        assertTrue("Missing tag result.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test support of multiple line comments disabled.
+     *
+     * @throws Exception
+     */
+    public void testMultipleLineCommentsDisabled()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/multiple-line-comments-disabled-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see that only the first line of the comment is captured.
+        String expected = "<td>This is line one,</td>";
+        assertTrue("Missing tag result.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test support of empty comments enabled.
+     *
+     * @throws Exception
+     */
+    public void testEmptyCommentsEnabled()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/empty-comments-enabled-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        mojo.execute();
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see that there was only one occurrence.
+        String expected = "<b>Number of occurrences found in the code: 1</b>";
+        assertTrue("Missing tag result.", htmlString.indexOf(expected) != -1);
+
+        // Use the resource bundle to determine what the no comment string
+        // is for the current locale.
+        ResourceBundle bundle = ResourceBundle.getBundle( "taglist-report" );
+        String noComment = bundle.getString("report.taglist.nocomment");
+
+        // Check to see that the empty comment message was entered
+        expected = "<td>--" + noComment + "--</td>";
+        assertTrue("Incorrect no comment message.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test support of empty comments disabled.
+     *
+     * @throws Exception
+     */
+    public void testEmptyCommentsDisabled()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/empty-comments-disabled-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see that there was zero tags found
+        String expected = "<td>@empty_comment</td><td>0</td>";
+        assertTrue("Missing tag result.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test support "tag" and "tag:" being the same tag.
+     *
+     * @throws Exception
+     */
+    public void testColonInComment()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/colons-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+        String xmlString = super.getGeneratedXMLOutput( mojo );
+
+        // Check to see that there were two tags found
+        String expected = "<tag name=\"@colons\" count=\"2\">";
+        assertTrue("Incorrect number of colon matches.", xmlString.indexOf(expected) != -1);
+
+        // Check for the tag without the colon
+        expected = "<td>This is without colon.</td>";
+        assertTrue("Missing without colon tag result.", htmlString.indexOf(expected) != -1);
+
+        // Check for the tag with the colon
+        expected = "<td>This is with colon.</td>";
+        assertTrue("Missing with tag result.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test support empty "tag" and "tag:".
+     *
+     * @throws Exception
+     */
+    public void testColonInEmptyComment()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/empty-colons-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Use the resource bundle to determine what the no comment string
+        // is for the current locale.
+        ResourceBundle bundle = ResourceBundle.getBundle( "taglist-report", Locale.ENGLISH );
+        String noComment = bundle.getString("report.taglist.nocomment");
+
+        // Check to see that there is a comment for line #40 (empty_no_colons)
+        // Since there is no text following the tag, the "No Comment" string should
+        // be inserted by the TagList Plugin
+        String expected = "<td>--" + noComment + "--</td><td>40</td>";
+        assertTrue("Incorrect empty tag without colon text.", htmlString.indexOf(expected) != -1);
+
+        // Check to see that there is a comment for line #43 (empty_colons)
+        // Since there is no text following the tag, the "No Comment" string should
+        // be inserted by the TagList Plugin
+        expected = "<td>--" + noComment + "--</td><td>43</td>";
+        assertTrue("Incorrect empty tag with colon text.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test support of show empty details enabled.
+     *
+     * @throws Exception
+     */
+    public void testShowEmptyDetailsEnabled()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/show-empty-details-enabled-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see show empty tags in code flag has a count of 1.
+        String expected = "@show_empty_details_tag_in_code</a></td><td>1</td>";
+        assertTrue("Incorrect count for the in code tag.", htmlString.indexOf(expected) != -1);
+
+        // Check to see show empty tags in not code flag has a count of 0.
+        expected = "@show_empty_details_tag_not_in_code</a></td><td>0</td>";
+        assertTrue("Incorrect count for the not in code tag.", htmlString.indexOf(expected) != -1);
+
+        // Check to see show empty tags in code section details exist (they should).
+        expected = "\">@show_empty_details_tag_in_code</a></h3>";
+        assertTrue("Missing tag details for the in code tag.", htmlString.indexOf(expected) != -1);
+
+        // Check to see show empty tags not in code section details exist (they should).
+        expected = "\">@show_empty_details_tag_not_in_code</a></h3>";
+        assertTrue("Missing tag details for the not in code tag.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test support of show empty details disabled.
+     *
+     * @throws Exception
+     */
+    public void testShowEmptyDetailsDisabled()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/show-empty-details-disabled-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see show empty tags in code flag has a count of 1.
+        String expected = "@show_empty_details_tag_in_code</a></td><td>1</td>";
+        assertTrue("Incorrect count for the in code tag.", htmlString.indexOf(expected) != -1);
+
+        // Check to see show empty tags in not code flag has a count of 0.
+        // FYI: Since there are no details, there is no ending hyperlink tag (</a>).
+        expected = "@show_empty_details_tag_not_in_code</td><td>0</td>";
+        assertTrue("Incorrect count for the not in code tag.", htmlString.indexOf(expected) != -1);
+
+        // Check to see show empty tags in code section details exist (they should).
+        expected = "\">@show_empty_details_tag_in_code</a></h3>";
+        assertTrue("Missing tag details for the in code tag.", htmlString.indexOf(expected) != -1);
+
+        // Check to see show empty tags not in code section details do NOT exist (they should not).
+        expected = "\">@show_empty_details_tag_not_in_code</a></h3>";
+        assertFalse("Unexpected tag details for the not in code tag.", htmlString.indexOf(expected) != -1);
+    }
+
+    public void testXmlFile()
+        throws Exception
+    {
+    	File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/basic-config-test/xml-output-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+        mojo.execute();
+        
+        String actualXml = super.getGeneratedXMLOutput( mojo );
+        actualXml = actualXml.replaceAll( "(\r\n)|(\r)", "\n" );
+        
+        File expectedFile = new File( getBasedir(), "/target/test-classes/unit/scala/basic-config-test/expected-taglist.xml" );
+        String expectedXml = FileUtils.fileRead( expectedFile, TEST_ENCODING );
+        expectedXml = expectedXml.replaceAll( "(\r\n)|(\r)", "\n" );
+
+        assertEquals( "unexpected contents", expectedXml, actualXml );
+    }
+}

--- a/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoCountingTagsTest.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoCountingTagsTest.java
@@ -1,0 +1,87 @@
+package org.codehaus.mojo.taglist.scala;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.mojo.taglist.AbstractTaglistMojoTestCase;
+import org.codehaus.mojo.taglist.TagListReport;
+
+import java.io.File;
+
+/**
+ * Test the Taglist mojo tags displayed on the website.
+ *
+ * @version $Id$
+ */
+public class TaglistMojoCountingTagsTest
+    extends AbstractTaglistMojoTestCase
+{
+    /** {@inheritDoc} */
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+    }
+
+    /** {@inheritDoc} */
+    protected void tearDown()
+        throws Exception
+    {
+        super.tearDown();
+    }    
+    
+    /**
+     * Test the counting tags example from the TagList website.
+     * 
+     * The purpose of this test is to guarantee that the information
+     * listed on the website matches what the taglist plugin will return.
+     *
+     * @throws Exception
+     */
+    public void testCountingTags()
+        throws Exception
+    {
+    	File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/counting-tags-test/counting-tags-pom.xml" );
+    	TagListReport mojo = super.getTagListReport( pluginXmlFile );
+        
+        // Run the TagList mojo
+        mojo.execute();
+        String htmlString = super.getGeneratedOutput( mojo );
+        
+        // Check that NOT_YET_DOCUMENTED does not show up.
+        String expected = "<td>NOT_YET_DOCUMENTED</td><td>0</td>";
+        assertTrue("Incorrect NOT_YET_DOCUMENTED tag result.", htmlString.indexOf(expected) != -1);
+        
+        // Check that FIXME has one tag.
+        expected = "\">FIXME</a></td><td>1</td>";
+        assertTrue("Incorrect FIXME tag result.", htmlString.indexOf(expected) != -1);
+        
+        // Check that DOCUMENT_ME does not show up.
+        expected = "<td>DOCUMENT_ME</td><td>0</td>";
+        assertTrue("Incorrect NOT_YET_DOCUMENTED tag result.", htmlString.indexOf(expected) != -1);
+        
+        // Check that <todo has one tag.
+        expected = "\">&lt;todo</a></td><td>1</td>";
+        assertTrue("Incorrect <todo tag result.", htmlString.indexOf(expected) != -1);
+        
+        // Check that @todo does not show up anywhere in the output.
+        String notExpected = "@todo";
+        assertTrue("Incorrect @todo tag result.", htmlString.indexOf(notExpected) == -1);
+    }
+}

--- a/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoLocalesTest.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoLocalesTest.java
@@ -1,0 +1,111 @@
+package org.codehaus.mojo.taglist.scala;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.mojo.taglist.AbstractTaglistMojoTestCase;
+import org.codehaus.mojo.taglist.TagListReport;
+
+import java.io.File;
+
+/**
+ * Test the Taglist mojo locale support
+ *
+ * @version $Id$
+ */
+public class TaglistMojoLocalesTest
+    extends AbstractTaglistMojoTestCase
+{
+
+    /** {@inheritDoc} */
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+    }
+
+    /** {@inheritDoc} */
+    protected void tearDown()
+        throws Exception
+    {
+        super.tearDown();
+    }
+ 
+    
+    /**
+     * Test when locale is set to English.
+     *
+     * @throws Exception
+     */
+    public void testEnglishLocale()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/locale-test/english-locale.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+        String xmlString = super.getGeneratedXMLOutput( mojo );
+
+
+        // Check to see that all three lines of the comment are captured.
+        String expected1 = "<td>Should match under Locale en  1 of 3.</td>";
+        assertTrue("Missing tag result #1.", htmlString.indexOf(expected1) != -1);
+        String expected2 = "<td>Should match under Locale en  2 of 3.</td>";
+        assertTrue("Missing tag result #2.", htmlString.indexOf(expected2) != -1);
+        String expected3 = "<td>Should match under Locale en  3 of 3.</td>";
+        assertTrue("Missing tag result #3.", htmlString.indexOf(expected3) != -1);
+        
+        // Check to see that all three lines of the comment are captured.
+        String expectedCount = "<tag name=\"EnglishLocale\" count=\"3\">";
+        assertTrue("Incorrect tag count.", xmlString.indexOf(expectedCount) != -1);
+    }
+    
+    /**
+     * Test when locale is set to Turkish.
+     *
+     * @throws Exception
+     */
+    public void testTurkishLocale()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/locale-test/turkish-locale.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+        String xmlString = super.getGeneratedXMLOutput( mojo );
+
+
+        // Check to see that all three lines of the comment are captured.
+        String expected1 = "<td>Should match under Locale tr  1 of 2.</td>";
+        assertTrue("Missing tag result #1.", htmlString.indexOf(expected1) != -1);
+        String expected2 = "<td>Should match under Locale tr  2 of 2.</td>";
+        assertTrue("Missing tag result #2.", htmlString.indexOf(expected2) != -1);
+        
+        // Check to see that all three lines of the comment are captured.
+        String expectedCount = "<tag name=\"Turkish Locale\" count=\"2\">";
+        assertTrue("Incorrect tag count.", xmlString.indexOf(expectedCount) != -1);
+    }
+    
+}

--- a/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoTagClassesTest.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoTagClassesTest.java
@@ -1,0 +1,162 @@
+package org.codehaus.mojo.taglist.scala;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+
+import org.codehaus.mojo.taglist.AbstractTaglistMojoTestCase;
+import org.codehaus.mojo.taglist.TagListReport;
+
+/**
+ * Test the Taglist mojo new tag class configurations.
+ *
+ * @version $Id$
+ */
+public class TaglistMojoTagClassesTest
+    extends AbstractTaglistMojoTestCase
+{
+
+    /** {@inheritDoc} */
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+    }
+
+    /** {@inheritDoc} */
+    protected void tearDown()
+        throws Exception
+    {
+        super.tearDown();
+    }
+
+    /**
+     * Test that the default match type is exact.
+     *
+     * @throws Exception
+     */
+    public void testDefaultExactMatch()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-classes-test/default-exact-match.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+        String xmlString = super.getGeneratedXMLOutput( mojo );
+
+        // Check to see that all three lines of the comment are captured.
+        String expected = "<td>This is the tag for the exact match default 1 of 1.</td>";
+        assertTrue("Missing tag result.", htmlString.indexOf(expected) != -1);
+        
+        // Check to see that all three lines of the comment are captured.
+        String expectedCount = "<tag name=\"Test Exact Matches (default)\" count=\"1\">";
+        assertTrue("Incorrect tag count.", xmlString.indexOf(expectedCount) != -1);
+    }
+    
+    /**
+     * Test the exact match.
+     *
+     * @throws Exception
+     */
+    public void testExactMatch()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-classes-test/exact-match.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+        String xmlString = super.getGeneratedXMLOutput( mojo );
+
+        // Check to see that all three lines of the comment are captured.
+        String expected = "<td>This is hte tag for the exact match 1 of 1.</td>";
+        assertTrue("Missing tag result.", htmlString.indexOf(expected) != -1);
+        
+        // Check to see that all three lines of the comment are captured.
+        String expectedCount = "<tag name=\"Test Exact Matches (configured)\" count=\"1\">";
+        assertTrue("Incorrect tag count.", xmlString.indexOf(expectedCount) != -1);
+    }
+    
+    /**
+     * Test the ignorecase match.
+     *
+     * @throws Exception
+     */
+    public void testIgnoreCaseMatch()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-classes-test/ignorecase-match.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+        String xmlString = super.getGeneratedXMLOutput( mojo );
+
+        // Check to see that all three lines of the comment are captured.
+        String expected1 = "<td>ignore case 1 of 3.</td>";
+        assertTrue("Missing tag result #1.", htmlString.indexOf(expected1) != -1);
+        String expected2 = "<td>ignore case 2 of 3.</td>";
+        assertTrue("Missing tag result #2.", htmlString.indexOf(expected2) != -1);
+        String expected3 = "<td>ignore case 3 of 3.</td>";
+        assertTrue("Missing tag result #3.", htmlString.indexOf(expected3) != -1);
+        
+        // Check to see that all three lines of the comment are captured.
+        String expectedCount = "<tag name=\"Test IgnoreCase Matches (configured)\" count=\"3\">";
+        assertTrue("Incorrect tag count.", xmlString.indexOf(expectedCount) != -1);
+    }
+    
+    /**
+     * Test the regular expression match.
+     *
+     * @throws Exception
+     */
+    public void testRegExMatch()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-classes-test/regex-match.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+        String xmlString = super.getGeneratedXMLOutput( mojo );
+
+        // Check to see that all three lines of the comment are captured.
+        String expected1 = "<td>reg ex match 1 of 3.</td>";
+        assertTrue("Missing tag result #1.", htmlString.indexOf(expected1) != -1);
+        String expected2 = "<td>reg ex match 2 of 3.</td>";
+        assertTrue("Missing tag result #2.", htmlString.indexOf(expected2) != -1);
+        String expected3 = "<td>reg ex match 3 of 3.</td>";
+        assertTrue("Missing tag result #3.", htmlString.indexOf(expected3) != -1);
+        
+        // Check to see that all three lines of the comment are captured.
+        String expectedCount = "<tag name=\"Test RegEx Matches (configured)\" count=\"3\">";
+        assertTrue("Incorrect tag count.", xmlString.indexOf(expectedCount) != -1);
+    }
+
+}

--- a/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoTagsTest.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/TaglistMojoTagsTest.java
@@ -1,0 +1,228 @@
+package org.codehaus.mojo.taglist.scala;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.mojo.taglist.AbstractTaglistMojoTestCase;
+import org.codehaus.mojo.taglist.TagListReport;
+
+import java.io.File;
+
+/**
+ * Test the Taglist mojo tags.
+ *
+ * @version $Id$
+ */
+public class TaglistMojoTagsTest
+    extends AbstractTaglistMojoTestCase
+{
+
+    /** {@inheritDoc} */
+    protected void setUp()
+        throws Exception
+    {
+        super.setUp();
+    }
+
+    /** {@inheritDoc} */
+    protected void tearDown()
+        throws Exception
+    {
+        super.tearDown();
+    }
+
+    /**
+     * Test the default tags.
+     *
+     * @throws Exception
+     */
+    public void testDefaultTags()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-test/default-tags-pom.xml" );
+
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        //Check to see that @todo has one occurance.
+        String expected = "\">@todo</a></td><td>1</td>";
+        assertTrue("Incorrect default @todo tag result.", htmlString.indexOf(expected) != -1);
+
+        //Check to see that @todo has one occurance.
+        expected = "\">TODO</a></td><td>1</td>";
+        assertTrue("Incorrect default TODO tag result.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test the C style tags.
+     *
+     *
+     * @throws Exception
+     */
+    public void testCTags()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-test/c-style-tags-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see that C++ style tag has one occurrence.
+        String expected = "\">c_style_tag</a></td><td>1</td>";
+        assertTrue("Incorrect C style tag result.", htmlString.indexOf(expected) != -1);
+
+        //Check to see that tag has the correct text.
+        expected = "<td>This is a C style tag.</td>";
+        assertTrue("Incorrect C style tag text.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test the C++ style tags.
+     *
+     * @throws Exception
+     */
+    public void testCPlusPlusTags()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-test/cplusplus-style-tags-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        //Check to see that C++ style tag has one occurrence.
+        String expected = "\">c++_style_tag</a></td><td>1</td>";
+        assertTrue("Incorrect C++ style tag result.", htmlString.indexOf(expected) != -1);
+
+        //Check to see that tag has the correct text.
+        expected = "<td>This is a C++ style tag.</td>";
+        assertTrue("Incorrect C++ style tag text.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test the JavaDoc single line style tags.
+     *
+     * This tests java doc comments that contain the tag on one line only.
+     *
+     * @throws Exception
+     */
+    public void testJavaDocSingleTags()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-test/javadoc-single-style-tags-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see that JavaDoc single style tag has one occurrence.
+        String expected = "\">javadoc_single_style_tag</a></td><td>1</td>";
+        assertTrue("Incorrect JavaDoc single style tag result.", htmlString.indexOf(expected) != -1);
+
+        // Check to see that tag has the correct text.
+        expected = "<td>This is a JavaDoc single style tag.</td>";
+        assertTrue("Incorrect JavaDoc single style tag text.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test the JavaDoc multi line style tags.
+     *
+     * This test java doc comments that contain the tag on the second line
+     * or later of the java doc comment.
+     *
+     * @throws Exception
+     */
+    public void testJavaDocMultiTags()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-test/javadoc-multi-style-tags-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see that JavaDoc style tag has one occurrence.
+        String expected = "\">javadoc_multi_style_tag</a></td><td>1</td>";
+        assertTrue("Incorrect JavaDoc multi style tag result.", htmlString.indexOf(expected) != -1);
+
+        // Check to see that tag has the correct text.
+        expected = "<td>This is a JavaDoc multi style tag.</td>";
+        assertTrue("Incorrect JavaDoc multi style tag text.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test the tags not at start of line.
+     *
+     * E.g. // This is a comment about @todo line.   <-- @todo didn't start line
+     *
+     * @throws Exception
+     */
+    public void testNotAtStartOfLineTags()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-test/not-start-line-tags-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see a tag not at the start of a line does not show up.
+        String expected = "<td>not_start_of_line_tag</td><td>0</td>";
+        assertTrue("Incorrect tag not at start of line tag result.", htmlString.indexOf(expected) != -1);
+    }
+
+    /**
+     * Test the source code with variables that match tag name.
+     *
+     * This test makes sure that source code with variable names
+     * that match to "tag" do not show up in the results.
+     *
+     * @throws Exception
+     */
+    public void testSourceCodeVariablesTags()
+        throws Exception
+    {
+        File pluginXmlFile = new File( getBasedir(), "/src/test/resources/unit/scala/tag-test/source-code-variable-tags-pom.xml" );
+        TagListReport mojo = super.getTagListReport( pluginXmlFile );
+
+        // Run the TagList mojo
+        mojo.execute();
+
+        String htmlString = super.getGeneratedOutput( mojo );
+
+        // Check to see a source code variable does not show up.
+        String expected = "<td>source_code_variable_tag</td><td>0</td>";
+        assertTrue("Incorrect source code variable tag result.", htmlString.indexOf(expected) != -1);
+    }
+}

--- a/src/test/java/org/codehaus/mojo/taglist/scala/stubs/BasicConfigProjectStub.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/stubs/BasicConfigProjectStub.java
@@ -1,0 +1,45 @@
+package org.codehaus.mojo.taglist.scala.stubs;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.plexus.PlexusTestCase;
+import java.util.List;
+import java.util.Collections;
+
+/**
+ * The Maven Project stub file for testing the plugin basic configuration.
+ * 
+ * This stub is used to get the test and source file directories.  This
+ * allows the TagList plugin unit.scala tests run against the unit.scala test directories
+ * instead of using the default project directories.
+ */
+public class BasicConfigProjectStub
+    extends org.apache.maven.plugin.testing.stubs.MavenProjectStub
+{	
+	public List getCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/basic-config-test/java-sources" );
+	}
+	
+	public List getTestCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/basic-config-test/test-sources" );
+	}	
+}

--- a/src/test/java/org/codehaus/mojo/taglist/scala/stubs/CountingTagsProjectStub.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/stubs/CountingTagsProjectStub.java
@@ -1,0 +1,46 @@
+package org.codehaus.mojo.taglist.scala.stubs;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.plexus.PlexusTestCase;
+
+import java.util.List;
+import java.util.Collections;
+
+/**
+ * The Maven Project stub file for testing the the website example tests.
+ * 
+ * This stub is used to get the test and source file directories.  This
+ * allows the TagList plugin unit.scala tests run against the unit.scala test directories
+ * instead of using the default project directories.
+ */
+public class CountingTagsProjectStub
+    extends org.apache.maven.plugin.testing.stubs.MavenProjectStub
+{	
+	public List getCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/counting-tags-test/java-sources" );
+	}
+	
+	public List getTestCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/counting-tags-test/test-sources" );
+	}	
+}

--- a/src/test/java/org/codehaus/mojo/taglist/scala/stubs/LocaleProjectStub.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/stubs/LocaleProjectStub.java
@@ -1,0 +1,45 @@
+package org.codehaus.mojo.taglist.scala.stubs;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.plexus.PlexusTestCase;
+import java.util.List;
+import java.util.Collections;
+
+/**
+ * The Maven Project stub file for testing the plugin new tag classes configuration.
+ * 
+ * This stub is used to get the test and source file directories.  This
+ * allows the TagList plugin unit.scala tests run against the unit.scala test directories
+ * instead of using the default project directories.
+ */
+public class LocaleProjectStub
+    extends org.apache.maven.plugin.testing.stubs.MavenProjectStub
+{	
+	public List getCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/locale-test/java-sources" );
+	}
+	
+	public List getTestCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/locale-test/test-sources" );
+	}	
+}

--- a/src/test/java/org/codehaus/mojo/taglist/scala/stubs/TagClassesProjectStub.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/stubs/TagClassesProjectStub.java
@@ -1,0 +1,45 @@
+package org.codehaus.mojo.taglist.scala.stubs;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.plexus.PlexusTestCase;
+import java.util.List;
+import java.util.Collections;
+
+/**
+ * The Maven Project stub file for testing the plugin new tag classes configuration.
+ * 
+ * This stub is used to get the test and source file directories.  This
+ * allows the TagList plugin unit.scala tests run against the unit.scala test directories
+ * instead of using the default project directories.
+ */
+public class TagClassesProjectStub
+    extends org.apache.maven.plugin.testing.stubs.MavenProjectStub
+{	
+	public List getCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/tag-classes-test/java-sources" );
+	}
+	
+	public List getTestCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/tag-classes-test/test-sources" );
+	}	
+}

--- a/src/test/java/org/codehaus/mojo/taglist/scala/stubs/TagsProjectStub.java
+++ b/src/test/java/org/codehaus/mojo/taglist/scala/stubs/TagsProjectStub.java
@@ -1,0 +1,46 @@
+package org.codehaus.mojo.taglist.scala.stubs;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.plexus.PlexusTestCase;
+
+import java.util.List;
+import java.util.Collections;
+
+/**
+ * The Maven Project stub file for testing the different types of tags.
+ * 
+ * This stub is used to get the test and source file directories.  This
+ * allows the TagList plugin unit.scala tests run against the unit.scala test directories
+ * instead of using the default project directories.
+ */
+public class TagsProjectStub
+    extends org.apache.maven.plugin.testing.stubs.MavenProjectStub
+{	
+	public List getCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/tag-test/java-sources" );
+	}
+	
+	public List getTestCompileSourceRoots()
+	{
+		return Collections.singletonList( PlexusTestCase.getBasedir() + "/target/test-classes/unit/scala/tag-test/test-sources" );
+	}	
+}

--- a/src/test/resources/org/codehaus/mojo/taglist/beans/XYjavatest.scala
+++ b/src/test/resources/org/codehaus/mojo/taglist/beans/XYjavatest.scala
@@ -1,0 +1,6 @@
+package org.codehaus.mojo.taglist.beans
+
+class XYjavatest
+{
+    // TODO something
+}

--- a/src/test/resources/unit/scala/aggregate-test/aggregate-pom.xml
+++ b/src/test/resources/unit/scala/aggregate-test/aggregate-pom.xml
@@ -1,0 +1,46 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo Aggregate</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+          <project implementation="org.codehaus.mojo.taglist.scala.stubs.TagListProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/aggregate-test/outputDirectory</outputDirectory>
+          <aggregate>true</aggregate>
+          <tags>
+            <tag>@todo</tag>
+          </tags>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/colons-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/colons-pom.xml
@@ -1,0 +1,46 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <tags>
+            <tag>@colons</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/create-output-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/create-output-pom.xml
@@ -1,0 +1,46 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <tags>
+            <tag>@create_output</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/empty-colons-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/empty-colons-pom.xml
@@ -1,0 +1,48 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <emptyComments>true</emptyComments>
+          <tags>
+            <tag>@empty_no_colons</tag>
+            <tag>@empty_colons</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/empty-comments-disabled-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/empty-comments-disabled-pom.xml
@@ -1,0 +1,47 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <emptyComments>false</emptyComments>
+          <tags>
+            <tag>@empty_comment</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/empty-comments-enabled-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/empty-comments-enabled-pom.xml
@@ -1,0 +1,47 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <emptyComments>true</emptyComments>
+          <tags>
+            <tag>@empty_comment</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/expected-taglist.xml
+++ b/src/test/resources/unit/scala/basic-config-test/expected-taglist.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report xmlns="org.codehaus.mojo.taglist-maven-plugin">
+  <tags>
+    <tag name="@create_output" count="1">
+      <files>
+        <file name="com.BasicConfig" count="1">
+          <comments>
+            <comment>
+              <lineNumber>11</lineNumber>
+              <comment>This is the tag for the output test.</comment>
+            </comment>
+          </comments>
+        </file>
+      </files>
+    </tag>
+  </tags>
+</report>

--- a/src/test/resources/unit/scala/basic-config-test/java-sources/com/BasicConfig.scala
+++ b/src/test/resources/unit/scala/basic-config-test/java-sources/com/BasicConfig.scala
@@ -1,0 +1,57 @@
+package com;
+
+/** This is the basic config test class.
+  *
+  * 
+  */
+class BasicConfig
+{
+	/** This is the test for the output file check.
+	 * 
+	 * @create_output: This is the tag for the output test.
+	 */
+	def basic1() { }
+	
+	/** Multiple line comments tests.
+	 * 
+	 * @multiple_line_comment: This is line one,
+	 * this is line two,
+	 * and this is line three.
+	 */
+	def basic2() { }
+	
+	/** Empty comments tests.
+	 * 
+	 * @empty_comment
+	 */
+	def basic3() { }
+	
+	/** Colons tests.
+	 * 
+	 * @colons This is without colon.
+	 * 
+	 * @colons: This is with colon.
+	 */
+	def basic3() { }
+	
+	/** Empty comments and colons tests.
+	 * 
+	 * NOTE:  The following tag MUST be on line #40 for the unit.scala test to pass.
+	 * @empty_no_colons
+	 * 
+	 * NOTE:  The following tag MUST be on line #43 for the unit.scala test to pass.
+	 * @empty_colons:
+	 */
+	def basic3() { }
+	
+	/** Show empty details tests.
+	 * 
+	 * @show_empty_details_tag_in_code this tag is in the Java code
+	 * 
+	 * NOTE:  The tag @show_empty_details_tag_not_in_code is NOT here on 
+	 */
+	def basic4() { }
+	
+	
+
+};

--- a/src/test/resources/unit/scala/basic-config-test/multiple-line-comments-disabled-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/multiple-line-comments-disabled-pom.xml
@@ -1,0 +1,47 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <multipleLineComments>false</multipleLineComments>
+          <tags>
+            <tag>@multiple_line_comment</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/multiple-line-comments-enabled-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/multiple-line-comments-enabled-pom.xml
@@ -1,0 +1,47 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <multipleLineComments>true</multipleLineComments>
+          <tags>
+            <tag>@multiple_line_comment</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/show-empty-details-disabled-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/show-empty-details-disabled-pom.xml
@@ -1,0 +1,48 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <showEmptyDetails>false</showEmptyDetails>
+          <tags>
+            <tag>@show_empty_details_tag_in_code</tag>
+            <tag>@show_empty_details_tag_not_in_code</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/show-empty-details-enabled-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/show-empty-details-enabled-pom.xml
@@ -1,0 +1,48 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <showEmptyDetails>true</showEmptyDetails>
+          <tags>
+            <tag>@show_empty_details_tag_in_code</tag>
+            <tag>@show_empty_details_tag_not_in_code</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/basic-config-test/xml-output-pom.xml
+++ b/src/test/resources/unit/scala/basic-config-test/xml-output-pom.xml
@@ -1,0 +1,47 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.BasicConfigProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/basic-config-test/outputDirectory</outputDirectory>
+          <showEmptyDetails>false</showEmptyDetails>
+          <tags>
+            <tag>@create_output</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/counting-tags-test/counting-tags-pom.xml
+++ b/src/test/resources/unit/scala/counting-tags-test/counting-tags-pom.xml
@@ -1,0 +1,50 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.CountingTagsProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/counting-tags-test/outputDirectory</outputDirectory>
+          <tags>
+            <tag>TODO</tag>
+            <tag>&lt;todo</tag>
+            <tag>FIXME</tag>
+            <tag>DOCUMENT_ME</tag>
+            <tag>NOT_YET_DOCUMENTED</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/counting-tags-test/java-sources/taglist/counting-tags.scala
+++ b/src/test/resources/unit/scala/counting-tags-test/java-sources/taglist/counting-tags.scala
@@ -1,0 +1,29 @@
+package taglist
+ 
+ /**
+  * NOT_YET_DOCUMENTED
+  */
+ class Issue
+ {
+   /**
+    * A method.
+    * FIXME Describe what this method does
+    *
+    * @param i DOCUMENT_ME
+    * @return Something useful
+    */
+   def method(i : Integer) : Double =
+   {
+     // <todo> must be implemented
+     0
+   }
+
+   /**
+    * This method counts FIXME tags in the text.
+    */
+   private def countFixmeTags(text: String ) : Int =
+   {
+     // @todo Implement this later
+     Integer.MIN_VALUE
+   }
+}

--- a/src/test/resources/unit/scala/locale-test/english-locale.xml
+++ b/src/test/resources/unit/scala/locale-test/english-locale.xml
@@ -1,0 +1,62 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project>
+	<groupId>org.codehaus.mojo</groupId>
+	<artifactId>test-taglist-mojo</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>Test TagList Mojo</name>
+	<modelVersion>4.0.0</modelVersion>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>taglist-maven-plugin</artifactId>
+				<configuration>
+					<project implementation="org.codehaus.mojo.taglist.scala.stubs.LocaleProjectStub"/>
+					<outputDirectory>${basedir}/target/test-classes/unit/scala/tag-classes-test/outputDirectory</outputDirectory>
+					<sourceFileLocale>en</sourceFileLocale>
+					<tagListOptions>
+						<tagClasses>
+							<tagClass>
+								<displayName>EnglishLocale</displayName>
+								<tags>
+									<tag>
+										<matchString>EnglishLocaleExactTag</matchString>
+										<matchType>exact</matchType>
+									</tag>
+									<tag>
+										<matchString>englishlocaleignorecasetag</matchString>
+										<matchType>ignoreCase</matchType>
+									</tag>
+									<tag>
+										<matchString>EnglishLocaleRegEx[0-9]Tag</matchString>
+										<matchType>regEx</matchType>
+									</tag>
+								</tags>
+							</tagClass>
+						</tagClasses>
+					</tagListOptions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/unit/scala/locale-test/java-sources/com/LocaleClass.java
+++ b/src/test/resources/unit/scala/locale-test/java-sources/com/LocaleClass.java
@@ -1,0 +1,32 @@
+package com;
+
+/** This is the Locale test class.
+  *
+  * 
+  */
+class LocaleClass
+{
+	/** This is the test for an English comment.
+	 * 
+	 * EnglishLocaleExactTag: Should match under Locale en  1 of 3.
+	 * 
+	 * EnglishLocaleIgnoreCaseTag: Should match under Locale en  2 of 3.
+	 * 
+	 * EnglishLocaleRegEx7Tag: Should match under Locale en  3 of 3.
+	 */
+	void tc1() { }
+	
+	/** This is the test for an Turkish comment.
+	 * 
+	 * TurkishLocaleExactTag: Should match under Locale tr  1 of 2.
+	 * 
+	 * TurkishLocaleIgnoreCaseTag: Will not match in Turkish Locale because toLower of 'I'.
+	 * 
+	 * TurkishLocaleRegEx7Tag: Should match under Locale tr  2 of 2.
+	 */
+	void tc2() { }
+	
+	
+	
+
+};

--- a/src/test/resources/unit/scala/locale-test/turkish-locale.xml
+++ b/src/test/resources/unit/scala/locale-test/turkish-locale.xml
@@ -1,0 +1,62 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project>
+	<groupId>org.codehaus.mojo</groupId>
+	<artifactId>test-taglist-mojo</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>Test TagList Mojo</name>
+	<modelVersion>4.0.0</modelVersion>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>taglist-maven-plugin</artifactId>
+				<configuration>
+					<project implementation="org.codehaus.mojo.taglist.scala.stubs.LocaleProjectStub"/>
+					<outputDirectory>${basedir}/target/test-classes/unit/scala/tag-classes-test/outputDirectory</outputDirectory>
+					<sourceFileLocale>tr</sourceFileLocale>
+					<tagListOptions>
+						<tagClasses>
+							<tagClass>
+								<displayName>Turkish Locale</displayName>
+								<tags>
+									<tag>
+										<matchString>TurkishLocaleExactTag</matchString>
+										<matchType>exact</matchType>
+									</tag>
+									<tag>
+										<matchString>turkishlocaleignorecasetag</matchString>
+										<matchType>ignoreCase</matchType>
+									</tag>
+									<tag>
+										<matchString>TurkishLocaleRegEx[0-9]Tag</matchString>
+										<matchType>regEx</matchType>
+									</tag>
+								</tags>
+							</tagClass>
+						</tagClasses>
+					</tagListOptions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/unit/scala/tag-classes-test/default-exact-match.xml
+++ b/src/test/resources/unit/scala/tag-classes-test/default-exact-match.xml
@@ -1,0 +1,53 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project>
+	<groupId>org.codehaus.mojo</groupId>
+	<artifactId>test-taglist-mojo</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>Test TagList Mojo</name>
+	<modelVersion>4.0.0</modelVersion>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>taglist-maven-plugin</artifactId>
+				<configuration>
+					<project implementation="org.codehaus.mojo.taglist.scala.stubs.TagClassesProjectStub"/>
+					<outputDirectory>${basedir}/target/test-classes/unit/scala/tag-classes-test/outputDirectory</outputDirectory>
+					<tagListOptions>
+						<tagClasses>
+							<tagClass>
+								<displayName>Test Exact Matches (default)</displayName>
+								<tags>
+									<tag>
+										<matchString>exactMatchDefaultString</matchString>
+									</tag>
+								</tags>
+							</tagClass>
+						</tagClasses>
+					</tagListOptions>
+					<fileSuffix>scala</fileSuffix>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/unit/scala/tag-classes-test/exact-match.xml
+++ b/src/test/resources/unit/scala/tag-classes-test/exact-match.xml
@@ -1,0 +1,54 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project>
+	<groupId>org.codehaus.mojo</groupId>
+	<artifactId>test-taglist-mojo</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>Test TagList Mojo</name>
+	<modelVersion>4.0.0</modelVersion>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>taglist-maven-plugin</artifactId>
+				<configuration>
+					<project implementation="org.codehaus.mojo.taglist.scala.stubs.TagClassesProjectStub"/>
+					<outputDirectory>${basedir}/target/test-classes/unit/scala/tag-classes-test/outputDirectory</outputDirectory>
+					<tagListOptions>
+						<tagClasses>
+							<tagClass>
+								<displayName>Test Exact Matches (configured)</displayName>
+								<tags>
+									<tag>
+										<matchString>exactMatchString</matchString>
+										<matchType>exact</matchType>
+									</tag>
+								</tags>
+							</tagClass>
+						</tagClasses>
+					</tagListOptions>
+					<fileSuffix>scala</fileSuffix>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/unit/scala/tag-classes-test/expected-taglist.xml
+++ b/src/test/resources/unit/scala/tag-classes-test/expected-taglist.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report>
+  <tags>
+    <tag name="@show_empty_details_tag_in_code" count="1">
+      <files>
+        <file name="com.BasicConfig.scala" count="1">
+          <comments>
+            <comment>
+              <lineNumber>49</lineNumber>
+              <comment>this tag is in the Java code</comment>
+            </comment>
+          </comments>
+        </file>
+      </files>
+    </tag>
+    <tag name="@show_empty_details_tag_not_in_code" count="0" />
+  </tags>
+</report>

--- a/src/test/resources/unit/scala/tag-classes-test/ignorecase-match.xml
+++ b/src/test/resources/unit/scala/tag-classes-test/ignorecase-match.xml
@@ -1,0 +1,54 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project>
+	<groupId>org.codehaus.mojo</groupId>
+	<artifactId>test-taglist-mojo</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>Test TagList Mojo</name>
+	<modelVersion>4.0.0</modelVersion>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>taglist-maven-plugin</artifactId>
+				<configuration>
+					<project implementation="org.codehaus.mojo.taglist.scala.stubs.TagClassesProjectStub"/>
+					<outputDirectory>${basedir}/target/test-classes/unit/scala/tag-classes-test/outputDirectory</outputDirectory>
+					<tagListOptions>
+						<tagClasses>
+							<tagClass>
+								<displayName>Test IgnoreCase Matches (configured)</displayName>
+								<tags>
+									<tag>
+										<matchString>ignoreCase</matchString>
+										<matchType>ignoreCase</matchType>
+									</tag>
+								</tags>
+							</tagClass>
+						</tagClasses>
+					</tagListOptions>
+					<fileSuffix>.scala</fileSuffix>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/unit/scala/tag-classes-test/java-sources/com/TagClasses.scala
+++ b/src/test/resources/unit/scala/tag-classes-test/java-sources/com/TagClasses.scala
@@ -1,0 +1,47 @@
+package com;
+
+/** This is the tag classes test class.
+  *
+  * 
+  */
+class TagClasses
+{
+	/** This is the test for a defaulting exact match.
+	 * 
+	 * exactMatchDefaultString: This is the tag for the exact match default 1 of 1.
+	 * 
+	 * exactmatchDefaultString:  This should NOT match.
+	 */
+	def tc1() { }
+	
+	/** This is the test for a specified exact match.
+	 * 
+	 * exactMatchString:  This is hte tag for the exact match 1 of 1.
+	 * 
+	 * exactmatchstring:  This should NOT match.
+	 */
+	def tc2() { }
+	
+	/** This is the test case for the ignore case match.
+	 * 
+	 * ignoreCase:  ignore case 1 of 3.
+	 * igNorecAse:  ignore case 2 of 3.
+	 * IGNORECASE:  ignore case 3 of 3.
+	 * 
+	 * ignore2case:  This should NOT match.
+	 */
+	def tc3() { }
+	
+	/** This is the test case for the regular expression match.
+	 * 
+	 * regEx1:  reg ex match 1 of 3.
+	 * regEx2:  reg ex match 2 of 3.
+	 * regEx3:  reg ex match 3 of 3.
+	 * 
+	 * regEx44:  this should NOT match.
+	 */
+	def tc4() { }
+	
+	
+
+}

--- a/src/test/resources/unit/scala/tag-classes-test/regex-match.xml
+++ b/src/test/resources/unit/scala/tag-classes-test/regex-match.xml
@@ -1,0 +1,54 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project>
+	<groupId>org.codehaus.mojo</groupId>
+	<artifactId>test-taglist-mojo</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>Test TagList Mojo</name>
+	<modelVersion>4.0.0</modelVersion>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>taglist-maven-plugin</artifactId>
+				<configuration>
+					<project implementation="org.codehaus.mojo.taglist.scala.stubs.TagClassesProjectStub"/>
+					<outputDirectory>${basedir}/target/test-classes/unit/scala/tag-classes-test/outputDirectory</outputDirectory>
+					<tagListOptions>
+						<tagClasses>
+							<tagClass>
+								<displayName>Test RegEx Matches (configured)</displayName>
+								<tags>
+									<tag>
+										<matchString>regEx[0-9]:</matchString>
+										<matchType>regEx</matchType>
+									</tag>
+								</tags>
+							</tagClass>
+						</tagClasses>
+					</tagListOptions>
+					<fileSuffix>.scala</fileSuffix>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/unit/scala/tag-test/c-style-tags-pom.xml
+++ b/src/test/resources/unit/scala/tag-test/c-style-tags-pom.xml
@@ -1,0 +1,46 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.TagsProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/tag-test/outputDirectory</outputDirectory>
+          <tags>
+            <tag>c_style_tag</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/tag-test/cplusplus-style-tags-pom.xml
+++ b/src/test/resources/unit/scala/tag-test/cplusplus-style-tags-pom.xml
@@ -1,0 +1,46 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.TagsProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/tag-test/outputDirectory</outputDirectory>
+          <tags>
+            <tag>c++_style_tag</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/tag-test/default-tags-pom.xml
+++ b/src/test/resources/unit/scala/tag-test/default-tags-pom.xml
@@ -1,0 +1,43 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.TagsProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/tag-test/outputDirectory</outputDirectory>
+            <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/tag-test/java-sources/com/Tags.scala
+++ b/src/test/resources/unit/scala/tag-test/java-sources/com/Tags.scala
@@ -1,0 +1,71 @@
+package com;
+
+/** This is the tags test class.
+  *
+  * @todo: This is the default tag #1.
+  * TODO: This is the default tag #2.
+  *
+  */
+class Tags
+{
+  /** This is the test for the output file check.
+    *
+    * @create_output: This is the tag for the output test.
+    */
+  def tag1() { }
+
+  /** Test a C style comment in souce code.
+    *
+    */
+  def tag2()
+  {
+    /* c_style_tag: This is a C style tag. */
+  }
+
+  /** Test a C++ style comment in souce code.
+    *
+    */
+  def tag3()
+  {
+    // c++_style_tag: This is a C++ style tag.
+  }
+
+  /** Test a JavaDoc single style comment in souce code.
+    *
+    */
+  def tag4()
+  {
+/** javadoc_single_style_tag: This is a JavaDoc single style tag.
+	}
+	
+	/** Test a JavaDoc multi style comment in souce code.
+  *
+  */
+	void tag5() 
+	{
+		/** 
+  * javadoc_multi_style_tag: This is a JavaDoc multi style tag.
+  */
+	}
+	
+	/** Test a tag not at the start of a line.
+  *
+  */
+	void tag6() 
+	{
+		/** 
+  * The tag "not_start_of_line_tag" should NOT be found.
+  */
+	}
+	
+	/** Test a tag variable in source code.
+  *
+  */
+	void tag7() 
+	{
+		int source_code_variable_tag;
+		
+		source_code_variable_tag += 7;
+	}
+
+};

--- a/src/test/resources/unit/scala/tag-test/javadoc-multi-style-tags-pom.xml
+++ b/src/test/resources/unit/scala/tag-test/javadoc-multi-style-tags-pom.xml
@@ -1,0 +1,46 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.TagsProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/tag-test/outputDirectory</outputDirectory>
+          <tags>
+            <tag>javadoc_multi_style_tag</tag>
+          </tags>
+          <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/tag-test/javadoc-single-style-tags-pom.xml
+++ b/src/test/resources/unit/scala/tag-test/javadoc-single-style-tags-pom.xml
@@ -1,0 +1,46 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.TagsProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/tag-test/outputDirectory</outputDirectory>
+          <tags>
+            <tag>javadoc_single_style_tag</tag>
+          </tags>
+            <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/tag-test/not-start-line-tags-pom.xml
+++ b/src/test/resources/unit/scala/tag-test/not-start-line-tags-pom.xml
@@ -1,0 +1,46 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.TagsProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/tag-test/outputDirectory</outputDirectory>
+          <tags>
+            <tag>not_start_of_line_tag</tag>
+          </tags>
+            <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/scala/tag-test/source-code-variable-tags-pom.xml
+++ b/src/test/resources/unit/scala/tag-test/source-code-variable-tags-pom.xml
@@ -1,0 +1,46 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<project>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>test-taglist-mojo</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test TagList Mojo</name>
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <configuration>
+         <project implementation="org.codehaus.mojo.taglist.scala.stubs.TagsProjectStub"/>
+          <outputDirectory>${basedir}/target/test-classes/unit/scala/tag-test/outputDirectory</outputDirectory>
+          <tags>
+            <tag>source_code_variable_tag</tag>
+          </tags>
+            <fileSuffix>scala</fileSuffix>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
The plugin considers also tags in Scala sources (*.scala). The optional configuration tag '''fileSuffix''' allows '''.java''' and '''.scala'''. Default is '''.java'''.

I appreciate any suggestion about the directory structure of the tests.

I know Scala is not in the main focus of Maven.
