### PR TITLE
Add option 'sourceTypes' so that not only java files can be scanned.

### DIFF
--- a/src/main/java/org/codehaus/mojo/taglist/FileAnalyser.java
+++ b/src/main/java/org/codehaus/mojo/taglist/FileAnalyser.java
@@ -109,6 +109,11 @@ public class FileAnalyser
     private ArrayList tagClasses = new ArrayList();
 
     /**
+     * The supported source types.
+     */
+    private final String[] sourceTypes;
+
+    /**
      * Constructor.
      * 
      * @param report the MOJO that is using this analyzer.
@@ -124,6 +129,7 @@ public class FileAnalyser
         locale = report.getLocale();
         noCommentString = report.getBundle().getString( "report.taglist.nocomment" );      
         this.tagClasses = tagClasses;
+        this.sourceTypes = report.getSourceTypes();
     }
 
     /**
@@ -171,7 +177,7 @@ public class FileAnalyser
         {
             for ( Iterator iter = sourceDirs.iterator(); iter.hasNext(); )
             {
-                filesList.addAll( FileUtils.getFiles( new File( (String) iter.next() ), "**/*.java", null ) );
+                filesList.addAll( FileUtils.getFiles( new File( (String) iter.next() ), getIncludes(), null ) );
             }
         }
         catch ( IOException e )
@@ -179,6 +185,20 @@ public class FileAnalyser
             throw new MavenReportException( "Error while trying to find the files to scan.", e );
         }
         return filesList;
+    }
+
+    private String getIncludes()
+    {
+        StringBuilder s = new StringBuilder();
+        for ( int i = 0; i < sourceTypes.length; i++ ) {
+            if ( s.length() > 0 )
+            {
+                s.append( ',' );
+            }
+            s.append( "**/*" );
+            s.append( sourceTypes[i] );
+        }
+        return s.toString();
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/taglist/TagListReport.java
+++ b/src/main/java/org/codehaus/mojo/taglist/TagListReport.java
@@ -228,6 +228,14 @@ public class TagListReport
     private org.codehaus.mojo.taglist.options.TagListOptions tagListOptions;
 
     /**
+     * A comma separated list of source types to be scanned, for example '.java,.scala'.
+     *
+     * @parameter default-value=".java"
+     * @since 2.5
+     */
+    private String sourceTypes;
+
+    /**
      * {@inheritDoc}
      * 
      * @see org.apache.maven.reporting.AbstractMavenReport#executeReport(java.util.Locale)
@@ -503,7 +511,7 @@ public class TagListReport
             for ( int i = 0; i < files.length && !found; i++ )
             {
                 File currentFile = files[i];
-                if ( currentFile.isFile() && currentFile.getName().endsWith( ".java" ) )
+                if ( currentFile.isFile() && isSourceFile( currentFile.getName() ))
                 {
                     found = true;
                 }
@@ -700,4 +708,29 @@ public class TagListReport
         return ResourceBundle.getBundle( "taglist-report", locale, this.getClass().getClassLoader() );
     }
 
+    /**
+     * Return the source types to scan. The default is '.java'.
+     *
+     * @return the source types to scan.
+     */
+    public String[] getSourceTypes()
+    {
+        if ( sourceTypes != null )
+        {
+            return sourceTypes.toLowerCase().split("[, ]+");
+        } else {
+            return new String[] { ".java" };
+        }
+    }
+
+    public boolean isSourceFile( String name )
+    {
+        String[] types = getSourceTypes();
+        for ( int i = 0; i < types.length; i++ ) {
+            if ( name.toLowerCase().endsWith( types[i]) ) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/codehaus/mojo/taglist/beans/FileReport.java
+++ b/src/main/java/org/codehaus/mojo/taglist/beans/FileReport.java
@@ -164,7 +164,9 @@ public class FileReport
             IOUtil.close( reader );
         }
 
-        className = packageName + "." + file.getName().replaceAll( "\\.java$", "" );
+        String ext = file.getName().substring(file.getName().lastIndexOf('.') + 1, file.getName().length());
+
+        className = packageName + "." + file.getName().replaceAll( "\\." + ext + '$', "" );
 
         return className;
     }


### PR DESCRIPTION
I would like to be able to generate taglist reports for mixed java/scala projects.

In order to support this I added a property called 'sourceTypes' which is a comma separated list of file extensions to accept.

Setting <sourceTypes>.java,.scala</sourceTypes> allows scanning all java and scala files in a project.