### PR TITLE
[#64] Allow empty displayName tags in TagClass.

### DIFF
--- a/src/main/java/org/codehaus/mojo/taglist/beans/TagReport.java
+++ b/src/main/java/org/codehaus/mojo/taglist/beans/TagReport.java
@@ -104,7 +104,7 @@ public class TagReport implements Comparable<TagReport> {
      * @return the name of the tag class.
      */
     public String getTagName() {
-        return displayName;
+        return displayName != null ? displayName : tagStrings.get(0);
     }
 
     /**


### PR DESCRIPTION
fixes #64.
Will be merged after tests are fixed